### PR TITLE
Configurable `KeyCache.redis` instance with fallback to current `Redis.current` usage.

### DIFF
--- a/lib/key_cache.rb
+++ b/lib/key_cache.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 require 'key_cache/version'
+require 'key_cache/configuration'
 require 'key_cache/cache'

--- a/lib/key_cache/cache.rb
+++ b/lib/key_cache/cache.rb
@@ -61,7 +61,7 @@ module KeyCache
 
         class_eval <<-METHOD, __FILE__, __LINE__ + 1
           def #{method}
-            Redis.current.get(cache_key_decode("#{key}"))
+            KeyCache.redis.get(cache_key_decode("#{key}"))
           end
 
           def #{method}_key
@@ -73,13 +73,13 @@ module KeyCache
           end
 
           def save_#{method}
-            Redis.current.set(cache_key_decode("#{key}"), self.send("#{value.to_sym}"))
+            KeyCache.redis.set(cache_key_decode("#{key}"), self.send("#{value.to_sym}"))
           end
 
           #{"after_save :save_#{method}" if include_callbacks}
 
           def destroy_#{method}
-            Redis.current.del(cache_key_decode("#{key}"))
+            KeyCache.redis.del(cache_key_decode("#{key}"))
           end
 
           #{"after_destroy :destroy_#{method}" if include_callbacks}
@@ -98,7 +98,7 @@ module KeyCache
 
         class_eval <<-METHOD, __FILE__, __LINE__ + 1
           def #{method}
-            Redis.current.hget(cache_key_decode("#{key}"), self.send("#{field}"))
+            KeyCache.redis.hget(cache_key_decode("#{key}"), self.send("#{field}"))
           end
 
           def #{method}_key
@@ -106,15 +106,15 @@ module KeyCache
           end
 
           def #{method}_keys
-            Redis.current.hkeys(cache_key_decode("#{key}"))
+            KeyCache.redis.hkeys(cache_key_decode("#{key}"))
           end
 
           def #{method}_values
-            Redis.current.hvals(cache_key_decode("#{key}"))
+            KeyCache.redis.hvals(cache_key_decode("#{key}"))
           end
 
           def #{method}_hash
-            Redis.current.hgetall(cache_key_decode("#{key}"))
+            KeyCache.redis.hgetall(cache_key_decode("#{key}"))
           end
 
           def #{method}_redis_key
@@ -123,14 +123,14 @@ module KeyCache
 
           def save_#{method}
             return if #{soft_deletion} && self.deleted_at.present?
-            Redis.current.hset(cache_key_decode("#{key}"), self.send("#{field}"), self.send("#{value.to_sym}"))
+            KeyCache.redis.hset(cache_key_decode("#{key}"), self.send("#{field}"), self.send("#{value.to_sym}"))
           end
 
           #{"after_save :save_#{method}" if include_callbacks}
 
           def destroy_#{method}
             return if #{soft_deletion} && self.deleted_at.nil?
-            Redis.current.hdel(cache_key_decode("#{key}"), self.send("#{field}"))
+            KeyCache.redis.hdel(cache_key_decode("#{key}"), self.send("#{field}"))
           end
 
           #{"after_destroy :destroy_#{method}" if include_callbacks}

--- a/lib/key_cache/configuration.rb
+++ b/lib/key_cache/configuration.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module KeyCache
+  class << self
+    attr_writer :redis
+
+    def redis
+      @redis || raise(ArgumentError, "KeyCache.redis is not configured")
+    end
+
+    def configure
+      yield self
+    end
+  end
+end

--- a/lib/key_cache/configuration.rb
+++ b/lib/key_cache/configuration.rb
@@ -5,7 +5,9 @@ module KeyCache
     attr_writer :redis
 
     def redis
-      @redis || raise(ArgumentError, "KeyCache.redis is not configured")
+      @redis ||
+        (Redis.current if defined?(Redis) && Redis.respond_to?(:current)) ||
+        raise(ArgumentError, "KeyCache.redis is not configured")
     end
 
     def configure

--- a/lib/key_cache/version.rb
+++ b/lib/key_cache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module KeyCache
-  VERSION = '0.0.6'.freeze
+  VERSION = '0.1.0'.freeze
 end

--- a/lib/key_cache/version.rb
+++ b/lib/key_cache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module KeyCache
-  VERSION = '0.0.5'.freeze
+  VERSION = '0.0.6'.freeze
 end


### PR DESCRIPTION
## Remove `Redis.current` (0.1.0)

`Redis.current` was deprecated in redis-rb 4.6 and removed in 5.0. This release introduces explicit Redis configuration to get ahead of that removal.

### What changed

- All internal `Redis.current` calls replaced with `KeyCache.redis`
- New `KeyCache.configure` block and `KeyCache.redis=` setter
- Falls back to `Redis.current` when `KeyCache.redis` is not configured, preserving backward compatibility

### Backward compatibility

No changes required to existing apps — the fallback ensures everything keeps working. However, consuming apps should add the initializer to prepare for `1.0.0`, which will drop `Redis.current` support entirely.

### Migration

Add an initializer in each consuming app:

```ruby
# config/initializers/key_cache.rb
KeyCache.configure do |config|
  config.redis = Redis.new(url: ENV['REDIS_URL'])
end
```

**Note:** This migration will affect every or virtually every rails project we have and is an amazing candidate for rl-orchestrator driving the update across the board.